### PR TITLE
Changed the width of CTA in Hero Section

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -18,7 +18,7 @@ export default function Hero() {
                     </h1>
 
                     <a
-                        className="self-center sm:self-start shadow-sm px-4 py-3 bg-gradient-to-r from-indigo-600 to-indigo-500 rounded-md my-8 w-3/4 font-semibold flex items-center justify-start"
+                        className="self-center sm:self-start shadow-sm px-4 py-3 bg-gradient-to-r from-indigo-600 to-indigo-500 rounded-md my-8 max-w-lg font-semibold flex items-center justify-start"
                         href={discordURL}
                         target="_blank"
                         rel="noopener noreferrer"


### PR DESCRIPTION
- **TITLE** : Changed the width of CTA in Hero Section.

- **DESCRIPTION** : The "Join us on Discord" button in the hero section was having an odd width in Laptop view, but was looking good in mobile view. So I have changed the width to look similar in both devices.

- **SCREENSHOTS** : 
> Laptop View : 
![image](https://github.com/onebytesocial/onebytesocial-website/assets/110488337/89a00196-8565-4b20-be53-87bf36b1bb9f)

> Mobile View : 
![image](https://github.com/onebytesocial/onebytesocial-website/assets/110488337/405f1edb-2675-4c18-897d-df776cb74678)
